### PR TITLE
Use the main branch of pgbench-collector with fixes

### DIFF
--- a/.vendor_urls
+++ b/.vendor_urls
@@ -1,1 +1,1 @@
-pgbench-collector https://github.com/gregburek/pgbench-tools/tarball/master
+pgbench-collector https://github.com/petergeoghegan/pgbench-tools/tarball/master


### PR DESCRIPTION
This restores pg's repo as what is used by pgperf. My own fork was used until https://github.com/petergeoghegan/pgbench-collector/commit/40628562fb78bf446c9925a21161f4b22f8426cf was merged. 
